### PR TITLE
Change primary color in dark theme for higher contrast

### DIFF
--- a/src/themes/default.tsx
+++ b/src/themes/default.tsx
@@ -1,5 +1,6 @@
 import { createMuiTheme, responsiveFontSizes } from "@material-ui/core/styles";
 import grey from "@material-ui/core/colors/grey";
+import blue from "@material-ui/core/colors/blue";
 const lightBackground = "#fff";
 const darkBackground = grey[900];
 
@@ -121,6 +122,9 @@ export const darkTheme = responsiveFontSizes(createMuiTheme({
     MuiTypography: {
       root: {
         color: grey[400],
+      },
+      colorPrimary: {
+        color: blue[300],
       },
     },
   },


### PR DESCRIPTION
See https://github.com/open-rpc/open-rpc/issues/432:

Taking a look at a page like [open-rpc.org/use](https://open-rpc.org/use) in dark mode:

The background color is `212121`. The color of links is `3F51B5` based on `MuiTypography-colorPrimary`. The content of the links can be hard to read in some scenarios.

Using a tool like [WebAim's contrast checker](https://webaim.org/resources/contrastchecker/) this produces a contrast ratio of 2.34, not passing any standard for contrast. I'd suggest using a lighter color like `blue[300]` in the same spectrum to be more visible.